### PR TITLE
Modified openssl version to avoid bug in 1.0.1g version

### DIFF
--- a/clientLibReqs/dirac-make.py
+++ b/clientLibReqs/dirac-make.py
@@ -21,7 +21,7 @@ versions = { 'sqlite' : "3.6.20",
              'bzip2' : "1.0.5",
              'zlib' : "1.2.3",
              'ncurses' : "5.9",
-             'openssl' : "1.0.1g" }
+             'openssl' : "1.0.1h" }
 
 darwinVer = ch.getDarwinVersion()
 


### PR DESCRIPTION
There is a bug in openssl 1.0.1g version [1] that is fixed in 1.0.1h version.
Just update the openssl version fixes the problem. You can see the error in [2] and 
more info in [3].
@acasajus 

[1] https://github.com/openssl/openssl/issues/57
[2] http://askubuntu.com/questions/454575/error-255-when-trying-to-install-openssl-1-0-1g-from-source
[3] https://github.com/DIRACGrid/Externals/issues/5
