### PR TITLE
[v6r6p2] freetype 2.7.1

### DIFF
--- a/serverLibReqs/dirac-make.py
+++ b/serverLibReqs/dirac-make.py
@@ -21,7 +21,7 @@ ch = chClass( here )
 
 
 versions = { 'libart_lgpl' : "2.3.20",
-             'freetype' : "2.8",
+             'freetype' : "2.7.1",
              'libpng' : "1.6.29" }
 
 ch.setPackageVersions( versions )


### PR DESCRIPTION
Use 2.7.1 version of freetype instead of 2.8