### PR TITLE
Add python-json-logger as dependency

### DIFF
--- a/ClientPackages/dirac-make.py
+++ b/ClientPackages/dirac-make.py
@@ -20,6 +20,7 @@ chClass = getattr( chModule, "CompileHelper" )
 ch = chClass( here )
 
 versions = { 'simplejson' : "3.11.1",
+             'python-json-logger' : '0.1.8',
              # 'fuse-python' : "0.2",
              'pyparsing' : '2.2.0',
              'requests' : '2.18.1',


### PR DESCRIPTION
This library (https://github.com/madzak/python-json-logger) is used to format the logs as a json structure. It is used to setup the central logging system