### PR TITLE
updates/replacements

### DIFF
--- a/ClientPackages/dirac-make.py
+++ b/ClientPackages/dirac-make.py
@@ -26,7 +26,9 @@ versions = { 'simplejson' : "3.13.2",
              'requests' : '2.18.4',
              'futures' : '3.2.0',
              'certifi' : '2018.1.18',
-             'stomp.py' : '4.1.19'}
+             'stomp.py' : '4.1.19',
+             'subprocess32' : '3.2.7',
+             'enum34' : '1.1.6'}
 
 ch.setPackageVersions( versions )
 

--- a/pyPlotTools/dirac-make.py
+++ b/pyPlotTools/dirac-make.py
@@ -19,8 +19,8 @@ chClass = getattr( chModule, "CompileHelper" )
 
 ch = chClass( here )
 
-versions = { 'matplotlib' : '1.5.3',
-             'Pillow' : '3.1.1' }
+versions = { 'matplotlib' : '2.0.2',
+             'Pillow' : '4.2.1' }
 
 ch.setPackageVersions( versions )
 


### PR DESCRIPTION
The matplotlib and Pillow library boost are to be in sync with the content of v6r6p3 (which is the current production version.

subprocess32 and enum34 are drop-in replacements of subprocess and enum modules and its installation is suggested e.g. in http://doc.hc2.ch/python-2.7.9-docs-html/library/subprocess.html?highlight=subprocess#module-subprocess